### PR TITLE
Use miekg/dns instead of go's builtin resolver, so that we can set edns0

### DIFF
--- a/dnsconfig.go
+++ b/dnsconfig.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2012 The Go Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package srvclient
+
+import "net"
+
+type dnsConfig struct {
+	servers  []string // servers to use
+	search   []string // suffixes to append to local name
+	ndots    int      // number of dots in name to trigger absolute lookup
+	timeout  int      // seconds before giving up on packet
+	attempts int      // lost packets before giving up on server
+	rotate   bool     // round robin among servers
+}
+
+// See resolv.conf(5) on a Linux machine.
+// TODO(rsc): Supposed to call uname() and chop the beginning
+// of the host name to get the default search domain.
+func dnsReadConfig(filename string) (*dnsConfig, error) {
+	file, err := open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer file.close()
+	conf := &dnsConfig{
+		ndots:    1,
+		timeout:  5,
+		attempts: 2,
+	}
+	for line, ok := file.readLine(); ok; line, ok = file.readLine() {
+		f := getFields(line)
+		if len(f) < 1 {
+			continue
+		}
+		switch f[0] {
+		case "nameserver": // add one name server
+			if len(f) > 1 && len(conf.servers) < 3 { // small, but the standard limit
+				// One more check: make sure server name is
+				// just an IP address.  Otherwise we need DNS
+				// to look it up.
+				if net.ParseIP(f[1]) != nil {
+					conf.servers = append(conf.servers, f[1])
+				}
+			}
+
+		case "domain": // set search path to just this domain
+			if len(f) > 1 {
+				conf.search = []string{f[1]}
+			}
+
+		case "search": // set search path to given servers
+			conf.search = make([]string, len(f)-1)
+			for i := 0; i < len(conf.search); i++ {
+				conf.search[i] = f[i+1]
+			}
+
+		case "options": // magic options
+			for i := 1; i < len(f); i++ {
+				s := f[i]
+				switch {
+				case hasPrefix(s, "ndots:"):
+					n, _, _ := dtoi(s, 6)
+					if n < 1 {
+						n = 1
+					}
+					conf.ndots = n
+				case hasPrefix(s, "timeout:"):
+					n, _, _ := dtoi(s, 8)
+					if n < 1 {
+						n = 1
+					}
+					conf.timeout = n
+				case hasPrefix(s, "attempts:"):
+					n, _, _ := dtoi(s, 9)
+					if n < 1 {
+						n = 1
+					}
+					conf.attempts = n
+				case s == "rotate":
+					conf.rotate = true
+				}
+			}
+		}
+	}
+	return conf, nil
+}
+
+func hasPrefix(s, prefix string) bool {
+	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}

--- a/parse.go
+++ b/parse.go
@@ -1,0 +1,270 @@
+// Copyright (c) 2012 The Go Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package srvclient
+
+import (
+	"io"
+	"os"
+)
+
+type file struct {
+	file  *os.File
+	data  []byte
+	atEOF bool
+}
+
+func (f *file) close() { f.file.Close() }
+
+func (f *file) getLineFromData() (s string, ok bool) {
+	data := f.data
+	i := 0
+	for i = 0; i < len(data); i++ {
+		if data[i] == '\n' {
+			s = string(data[0:i])
+			ok = true
+			// move data
+			i++
+			n := len(data) - i
+			copy(data[0:], data[i:])
+			f.data = data[0:n]
+			return
+		}
+	}
+	if f.atEOF && len(f.data) > 0 {
+		// EOF, return all we have
+		s = string(data)
+		f.data = f.data[0:0]
+		ok = true
+	}
+	return
+}
+
+func (f *file) readLine() (s string, ok bool) {
+	if s, ok = f.getLineFromData(); ok {
+		return
+	}
+	if len(f.data) < cap(f.data) {
+		ln := len(f.data)
+		n, err := io.ReadFull(f.file, f.data[ln:cap(f.data)])
+		if n >= 0 {
+			f.data = f.data[0 : ln+n]
+		}
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
+			f.atEOF = true
+		}
+	}
+	s, ok = f.getLineFromData()
+	return
+}
+
+func open(name string) (*file, error) {
+	fd, err := os.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return &file{fd, make([]byte, 0, os.Getpagesize()), false}, nil
+}
+
+func byteIndex(s string, c byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
+}
+
+// Count occurrences in s of any bytes in t.
+func countAnyByte(s string, t string) int {
+	n := 0
+	for i := 0; i < len(s); i++ {
+		if byteIndex(t, s[i]) >= 0 {
+			n++
+		}
+	}
+	return n
+}
+
+// Split s at any bytes in t.
+func splitAtBytes(s string, t string) []string {
+	a := make([]string, 1+countAnyByte(s, t))
+	n := 0
+	last := 0
+	for i := 0; i < len(s); i++ {
+		if byteIndex(t, s[i]) >= 0 {
+			if last < i {
+				a[n] = string(s[last:i])
+				n++
+			}
+			last = i + 1
+		}
+	}
+	if last < len(s) {
+		a[n] = string(s[last:])
+		n++
+	}
+	return a[0:n]
+}
+
+func getFields(s string) []string { return splitAtBytes(s, " \r\t\n") }
+
+// Bigger than we need, not too big to worry about overflow
+const big = 0xFFFFFF
+
+// Decimal to integer starting at &s[i0].
+// Returns number, new offset, success.
+func dtoi(s string, i0 int) (n int, i int, ok bool) {
+	n = 0
+	for i = i0; i < len(s) && '0' <= s[i] && s[i] <= '9'; i++ {
+		n = n*10 + int(s[i]-'0')
+		if n >= big {
+			return 0, i, false
+		}
+	}
+	if i == i0 {
+		return 0, i, false
+	}
+	return n, i, true
+}
+
+// Hexadecimal to integer starting at &s[i0].
+// Returns number, new offset, success.
+func xtoi(s string, i0 int) (n int, i int, ok bool) {
+	n = 0
+	for i = i0; i < len(s); i++ {
+		if '0' <= s[i] && s[i] <= '9' {
+			n *= 16
+			n += int(s[i] - '0')
+		} else if 'a' <= s[i] && s[i] <= 'f' {
+			n *= 16
+			n += int(s[i]-'a') + 10
+		} else if 'A' <= s[i] && s[i] <= 'F' {
+			n *= 16
+			n += int(s[i]-'A') + 10
+		} else {
+			break
+		}
+		if n >= big {
+			return 0, i, false
+		}
+	}
+	if i == i0 {
+		return 0, i, false
+	}
+	return n, i, true
+}
+
+// xtoi2 converts the next two hex digits of s into a byte.
+// If s is longer than 2 bytes then the third byte must be e.
+// If the first two bytes of s are not hex digits or the third byte
+// does not match e, false is returned.
+func xtoi2(s string, e byte) (byte, bool) {
+	if len(s) > 2 && s[2] != e {
+		return 0, false
+	}
+	n, ei, ok := xtoi(s[:2], 0)
+	return byte(n), ok && ei == 2
+}
+
+// Integer to decimal.
+func itoa(i int) string {
+	var buf [30]byte
+	n := len(buf)
+	neg := false
+	if i < 0 {
+		i = -i
+		neg = true
+	}
+	ui := uint(i)
+	for ui > 0 || n == len(buf) {
+		n--
+		buf[n] = byte('0' + ui%10)
+		ui /= 10
+	}
+	if neg {
+		n--
+		buf[n] = '-'
+	}
+	return string(buf[n:])
+}
+
+// Convert i to decimal string.
+func itod(i uint) string {
+	if i == 0 {
+		return "0"
+	}
+
+	// Assemble decimal in reverse order.
+	var b [32]byte
+	bp := len(b)
+	for ; i > 0; i /= 10 {
+		bp--
+		b[bp] = byte(i%10) + '0'
+	}
+
+	return string(b[bp:])
+}
+
+const hexDigit = "0123456789abcdef"
+
+// Convert i to a hexadecimal string. Leading zeros are not printed.
+func appendHex(dst []byte, i uint32) []byte {
+	if i == 0 {
+		return append(dst, '0')
+	}
+	for j := 7; j >= 0; j-- {
+		v := i >> uint(j*4)
+		if v > 0 {
+			dst = append(dst, hexDigit[v&0xf])
+		}
+	}
+	return dst
+}
+
+// Number of occurrences of b in s.
+func count(s string, b byte) int {
+	n := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == b {
+			n++
+		}
+	}
+	return n
+}
+
+// Index of rightmost occurrence of b in s.
+func last(s string, b byte) int {
+	i := len(s)
+	for i--; i >= 0; i-- {
+		if s[i] == b {
+			break
+		}
+	}
+	return i
+}

--- a/srvclient.go
+++ b/srvclient.go
@@ -15,10 +15,14 @@ import (
 	"github.com/miekg/dns"
 )
 
+func init() {
+	go dnsConfigLoop()
+}
+
 func lookupSRV(hostname string) (*dns.Msg, error) {
-	cfg, err := dnsReadConfig("/etc/resolv.conf")
+	cfg, err := dnsGetConfig()
 	if err != nil {
-		return nil, fmt.Errorf("Could not parse /etc/resolv.conf: %s", err)
+		return nil, err
 	}
 
 	c := new(dns.Client)

--- a/srvclient/main.go
+++ b/srvclient/main.go
@@ -15,7 +15,7 @@ func main() {
 
 	r, err := srvclient.SRV(os.Args[1])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error resolving '%q': %s\n", os.Args[1], err)
+		fmt.Fprintf(os.Stderr, "error resolving %q: %s\n", os.Args[1], err)
 		os.Exit(2)
 	}
 

--- a/srvclient_test.go
+++ b/srvclient_test.go
@@ -1,15 +1,15 @@
 package srvclient
 
 import (
-	"net"
 	. "testing"
 
+	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
 )
 
-func testDistr(srvs []*net.SRV) map[string]int {
+func testDistr(srvs []*dns.SRV) map[string]int {
 	m := map[string]int{}
-	for i := 0; i < 100000; i++ {
+	for i := 0; i < 1000; i++ {
 		s := pickSRV(srvs)
 		m[s.Target]++
 	}
@@ -17,7 +17,7 @@ func testDistr(srvs []*net.SRV) map[string]int {
 }
 
 func TestPickSRV(t *T) {
-	srvs := []*net.SRV{
+	srvs := []*dns.SRV{
 		{Target: "a", Priority: 1, Weight: 100},
 		{Target: "b", Priority: 1, Weight: 100},
 	}
@@ -27,7 +27,7 @@ func TestPickSRV(t *T) {
 	assert.True(t, m["a"] > 0)
 	assert.True(t, m["b"] > 0)
 
-	srvs = []*net.SRV{
+	srvs = []*dns.SRV{
 		{Target: "a", Priority: 2, Weight: 100},
 		{Target: "b", Priority: 1, Weight: 100},
 		{Target: "c", Priority: 2, Weight: 100},
@@ -39,7 +39,7 @@ func TestPickSRV(t *T) {
 	assert.True(t, m["b"] > 0)
 	assert.True(t, m["d"] > 0)
 
-	srvs = []*net.SRV{
+	srvs = []*dns.SRV{
 		{Target: "a", Priority: 2, Weight: 100},
 		{Target: "b", Priority: 1, Weight: 50},
 		{Target: "c", Priority: 2, Weight: 100},


### PR DESCRIPTION
In doing this we've had to import a bunch of code from go's net package to read
the /etc/resolv.conf file, since miekg/dns needs to be given a nameserver to
communicate with
