### PR TITLE
Remove use of dns.ErrTruncated and added metrics

### DIFF
--- a/srvclient/main.go
+++ b/srvclient/main.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/miekg/dns"
-
 	"github.com/levenlabs/go-srvclient"
 	"github.com/mediocregopher/lever"
 )
@@ -48,8 +46,11 @@ func main() {
 	}
 
 	ignore := l.ParamFlag("--ignore")
+	if ignore {
+		sc.IgnoreTruncated = true
+	}
 	r, err := sc.SRV(argv[0])
-	if err != nil && (err != dns.ErrTruncated || !ignore || r == "") {
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "error resolving %q: %s\n", argv[0], err)
 		os.Exit(2)
 	}


### PR DESCRIPTION
ErrTruncated was removed in miekg/dns#815

Instead we're falling back to TCP now and added metrics so we can know when truncation is happening since its not passed to the caller anymore.