### PR TITLE
fix: check msg before copying

### DIFF
--- a/srvclient.go
+++ b/srvclient.go
@@ -329,7 +329,9 @@ func (sc *SRVClient) lookupSRV(ctx context.Context, hostname string, replaceWith
 		case <-ctx.Done():
 			err = ctx.Err()
 		case <-res.done:
-			msg = res.msg.Copy()
+			if res.msg != nil {
+				msg = res.msg.Copy()
+			}
 			err = res.err
 		}
 	} else {

--- a/srvclient_test.go
+++ b/srvclient_test.go
@@ -431,4 +431,7 @@ func TestSingleInFlight(t *testing.T) {
 	wg.Wait()
 	assert.EqualValues(t, 1, atomic.LoadInt64(&count))
 	assert.EqualValues(t, 1, client.Stats().InFlightHits)
+
+	_, err := client.SRVNoCacheContext(context.Background(), "fail")
+	assert.NotNil(t, err)
 }


### PR DESCRIPTION
If there's an error then we might try to copy a nil msg.